### PR TITLE
Do not unnecessarily rewrite output on update

### DIFF
--- a/collective/recipe/template/README.rst
+++ b/collective/recipe/template/README.rst
@@ -372,3 +372,57 @@ built:
   #
   My template knows about another buildout part:
   bar
+
+Unchanged output files are not rewritten on update
+==================================================
+
+When output content is unchanged, the output file is not rewritten on update.
+The advantage is that the modification timestamp of the file is not changed.
+(E.g. systemd notices if the timestamp of any unit files change, and issues
+helpful "nags" reminding the user to rerun "systemctl daemon-reload".)
+
+Note the mtime of the output file:
+  >>> from os.path import getmtime
+  >>> from time import sleep
+  >>> orig_mtime = getmtime('template')
+
+Wait until new files get a different mtime
+  >>> def mtime_tick():
+  ...     write('test.stamp', '')
+  ...     return getmtime('test.stamp') > orig_mtime
+  >>> wait_until('mtime_tick', mtime_tick)
+
+Rerun the buildout:
+  >>> print system(join('bin', 'buildout')),
+  Develop: '/sample-buildout/.'
+  Uninstalling other.
+  Installing other.
+  Updating template.
+
+The file's mtime is not changed:
+  >>> getmtime('template') == orig_mtime
+  True
+
+Change the template:
+  >>> write('template.in',
+  ... '''#
+  ... My template still knows about another buildout part:
+  ... Foo is ${other:foo}
+  ... ''')
+
+Rerun the buildout:
+  >>> print system(join('bin', 'buildout')),
+  Develop: '/sample-buildout/.'
+  Uninstalling other.
+  Installing other.
+  Updating template.
+
+The file's mtime is changed:
+  >>> getmtime('template') > orig_mtime
+  True
+
+The output has changed:
+  >>> cat('template')
+  #
+  My template still knows about another buildout part:
+  Foo is bar

--- a/collective/recipe/template/__init__.py
+++ b/collective/recipe/template/__init__.py
@@ -105,9 +105,19 @@ class Recipe:
 
 
     def update(self):
-        # Variables in other parts might have changed so we need to do a
+        # Variables in other parts might have changed so we may need to do a
         # full reinstall.
-        return self.install()
+        try:
+            input = open(self.output, "rt")
+        except IOError:
+            result_changed = True
+        else:
+            result_changed = input.read() != self.result
+            input.close()
+
+        if result_changed:
+            # Output has changed, re-write output file
+            return self.install()
 
 
     def createIntermediatePaths(self, path):

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,9 @@ Changelog
 1.14 (unreleased)
 =================
 
-- Nothing changed yet.
+- On update, do not rewrite the output file (thus preserving its
+  modification timestamp) unless its content has changed.
+  [dairiki]
 
 
 1.13 (2015-10-20)


### PR DESCRIPTION
Currently, the mtime of the template output file is updated every time buildout is run, even when the output has not changed.  This can cause grief is some circumstances.  For example, systemd checks the mtimes on its unit files, and, if any have changed, issues a helpful "please run systemctl daemon-reload" nag.  In other cases, the updated mtime may trigger an unnecessary compilation.

This PR makes it so that the output is rewritten on update only if it contents have changed.  It is still always rewritten on install (unless `overwrite` is set to false and the output already exists.)

(This is an alternative implementation of PR #9.)
