### PR TITLE
Write output with utf8 encoding

### DIFF
--- a/collective/recipe/template/__init__.py
+++ b/collective/recipe/template/__init__.py
@@ -88,7 +88,7 @@ class Recipe:
         except OSError:
             pass
         output=open(self.output, "wt")
-        output.write(self.result)
+        output.write(self.result.encode('utf-8'))
         output.close()
 
         if self.mode is not None:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 import os
 import sys
 
-version = '1.12'
+version = '1.12+md.2'
 
 genshi_requirement = 'Genshi'
 if sys.version_info >= (3,):


### PR DESCRIPTION
Genshi can handle templates containing non-ascii unicode text, but this recipe currently fails when writing the output to disk with the dreaded `'ascii' codec can't encode character...` exception.

This PR standardises the output encoding to utf8, as a reasonable default (nb: utf8 coincides with ascii on the characters they share, so this change is entirely backwards compatible).

Supporting other encodings would require passing an `encoding` parameter through to the various Genshi templating calls. I did investigate this, but the utf8 default turned out to be so much simpler I dropped the attempt.