### PR TITLE
Avoid to render the template out-of-order.

### DIFF
--- a/collective/recipe/template/__init__.py
+++ b/collective/recipe/template/__init__.py
@@ -57,8 +57,6 @@ class Recipe:
             self.logger.error(msg)
             raise zc.buildout.UserError(msg)
 
-        self._execute()
-
         if "mode" in options:
             self.mode=int(options["mode"], 8)
 
@@ -82,6 +80,8 @@ class Recipe:
         return True
 
     def install(self):
+        self._execute()
+
         if not self.overwrite and os.path.isfile(self.output):
             return self.options.created()
 


### PR DESCRIPTION
In a buildout setting like the following:

```
    [buildout]
    parts = after

    [after]
    datefile = ${before:datefile}
    recipe = collective.recipe.template[genshi]:genshi
    input = ${buildout:directory}/template/input.txt
    output = ${buildout:directory}/template/output.txt

    [before]
    recipe = collective.recipe.cmd
    datefile = ${buildout:directory}/template/date.txt
    shell = bash
    cmd =
       date +%FT%H-%M-%S > ${before:datefile}

```

The `input.txt` is something like:

```
    {%python

    def read(f):
    with open(f, 'rb') as fh:
    return f.read()

    %}

    This is the date: ${read(options['datefile'])}.
```

Notice that the part `after` implicitly depends on `before`, so it's expected
that `before` runs before `after`.  However, `collective.recipe.template`
renders the template when buildout initializes the recipe and we get.

In our example, the template expects the `date.txt` file to exists and fails
with `IOError: [Errno 2] No such file or directory: '/.../data.txt'`.

So, we should defer the rendering of the template to the 'install' and/or
'update' phase.